### PR TITLE
Fix: footer 24px margin top bug

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -74,7 +74,7 @@ footer > p {
     padding: 4px;
 }
 
-footer > :nth-child(3), :nth-child(5), :nth-child(7) {
+footer > :nth-child(3), footer > :nth-child(5), footer > :nth-child(7) {
     margin-top: 24px;
 }
 


### PR DESCRIPTION
Tidigare targeting inkluderade footerns tredje barn och sedan ANY fifth child och ANY seventh child

Kommer att omdesign hela footern från ett layout perspektiv (inte styling) för att följa best practices