### PR TITLE
Buy Now button styling on product-page-template.html

### DIFF
--- a/css/product-page.css
+++ b/css/product-page.css
@@ -86,9 +86,21 @@ p, h2, button {
     background-color: var(--green);
     color: white;
     padding: var(--content-padding-block) var(--content-padding-inline);
-    font-size: large;
+    font-size: 32px;
     font-weight: bold;
     border-radius: var(--button-border-radius);
+    font-family: "VT323", monospace;
+
+    /* We use shadows with 0 blur to create solid blocks of color */
+    box-shadow: 
+    /* The "Pixels" on the corners */
+    -6px 0 0 0 #000, 
+    6px 0 0 0 #000, 
+    0 -6px 0 0 #000, 
+    0 6px 0 0 #000;
+  
+    /* Some breathing room so that it doesn't touch other elements */
+    margin: 8px;
 }
 
 .product-buy-button:hover {

--- a/product-page-template.html
+++ b/product-page-template.html
@@ -6,6 +6,10 @@
     <title>Nshop</title>
     <link rel="stylesheet" href="css/general.css">
     <link rel="stylesheet" href="css/product-page.css">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
 </head>
 <body>
 


### PR DESCRIPTION
# Köp nu knappen styling
https://trello.com/c/j3iwsgj4/16-product-page-style-buy-now-button

Valde en standard grön färg #4CAF50 med en mörkare variant #45a049 när man hovrar och klickar på knappen.

Knappen lyfts även upp 2px när man hovrar över den. När man klickar åker den ner igen och blir lite mörkare.

Sista spice blev en "block border" och pixel fonten


Färdiga reslutatet:
<img width="288" height="176" alt="Screenshot from 2025-12-25 20-27-45" src="https://github.com/user-attachments/assets/b54a67ab-5df4-4cac-bec9-9d7f8035a1c1" />
