### PR TITLE
Fixed up button, added smooth scrolling and removed extra closing </head> tag

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -8,6 +8,10 @@
   --dark-red: #b52a36;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: Arial, Helvetica, sans-serif;

--- a/homepage.html
+++ b/homepage.html
@@ -9,7 +9,6 @@
 </head>
 <body>
 
-  </head>
   <body>
 
     <header id="header">
@@ -174,7 +173,7 @@
 
 
 
-    <a href="#header">
+    <a href="#">
         <img id="up" src="img/upp-knapp.png" alt="Pil uppåt som för en till toppen av sidan">
     </a>
 


### PR DESCRIPTION
# Summary
"Upp knappen" slutade fungera när headern blev position: fixed. I och med att headern alltid är på skärmen blir det när man är nere på sidan att browsern tänker scrolla till #header men märker "Jag ser redan header, jag behöver inte scrolla". 

Detta fixdes genom att ändra 
```
<a href="#header">
    <img id="up" src="img/upp-knapp.png" alt="Back to top">
</a>
```
till
```
<a href="#">
    <img id="up" src="img/upp-knapp.png" alt="Back to top">
</a>
```
`<a href="#">` betyder helt enkelt "top of page" vilket funkar perfekt i detta fall.

För att göra the transition upp till toppen av sidan mer smooth lades detta även till i general.css:
```
html {
  scroll-behavior: smooth;
}
```

Som en sista ändring i denna PR togs en extra closing </head> tag bort