### PR TITLE
Product page faeture section layout fix och desktop sizing

### DIFF
--- a/css/product-page.css
+++ b/css/product-page.css
@@ -191,7 +191,10 @@ p, h2, h4, button {
     .feature-section-text-wrapper {
         max-width: 35ch;
         width: 100%;
-        display: grid;
+    }
+
+    .feature-section-text-wrapper h3 {
+        padding-bottom: 12px;
     }
 
     .feature-section-media-wrapper {
@@ -230,7 +233,11 @@ p, h2, h4, button {
     }
 
     .feature-section-text-wrapper {
-        max-width: 60ch;
+        max-width: 65ch;
+        font-size: 18px;
+        display: flex;
+        flex-direction: column;
+        justify-content: start;
     }
 
     .feature-section-media-wrapper {

--- a/product-page-template.html
+++ b/product-page-template.html
@@ -80,7 +80,7 @@
             </section>
             <section class="product-feature-section">
                 <div class="feature-section-text-wrapper">
-                    <h4>Medium length features headline</h4>
+                    <h3>Medium length features headline</h3>
                     <p>This is just placeholder text. Don’t be alarmed, this is just here to fill up space since your finalized copy isn’t ready yet. Once we have your content finalized, we’ll replace this placeholder text with your real content.</p>
                     <br>
                     <p>There are other placeholder text alternatives like Hipster Ipsum, Zombie Ipsum, Bacon Ipsum, and many more. While often hilarious, these placeholder passages can also lead to much of the same confusion.</p>


### PR DESCRIPTION
* Ändrar feature section heading från h4 till h3
  * Lägger till padding-bottom till den så att det är space mellan heading och paragraferna
* Tar bort display: grid där det inte behövs och bara saboterar
* Sätter font-size: 18px; på large desktop