### PR TITLE
BUG FIX: Overflow issues on mobile allowing us to horizontally scroll

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -54,6 +54,11 @@ body {
         "main"
         "footer"
     ;
+
+    /* FIX: Detta förhindrar att man kan scrolla horizontellt på mobil.
+    Istället för att använda default grid-template-columns: minmax(auto, 1fr)
+    använder vi grid-template-columns: minmax(0, 1fr) vilket gör att columnerna kan
+    shrink när det behövs (t.ex. på mobil) */
     grid-template-columns: minmax(0, 1fr);
 }
 


### PR DESCRIPTION
# Summary
Fixar en bug gör nav till 626px på mobil vilket är mycket mer än t.ex. 375px på en iPhone SE vilket gör att vi kan scrolla horizontellt vilket är usel UX haha
![Nshop (3)](https://github.com/user-attachments/assets/bcea4a19-dcc0-408b-9b83-bdeb627678b3)

## The fix
Fixen är endast en rad kod i general.css!
```
body {
    margin: 0;
    font-family: Arial, Helvetica, sans-serif;
    color: var(--white); /* Override whenever needed */
    display: grid;
    grid-template-areas: 
        "header"
        "main"
        "footer"
    ;

    /* FIX: Detta förhindrar att man kan scrolla horizontellt på mobil.
    Istället för att använda default grid-template-columns: minmax(auto, 1fr)
    använder vi grid-template-columns: minmax(0, 1fr) vilket gör att columnerna kan
    shrink när det behövs (t.ex. på mobil) */
    grid-template-columns: minmax(0, 1fr);
}
```
Precis som kommentaren säger så använder vi minmax(0, 1fr) för att låta kolumnerna krympa ifall det behövs

## The result
<img width="1921" height="1097" alt="Screenshot from 2025-12-31 15-49-54" src="https://github.com/user-attachments/assets/3224808c-c9d3-4974-a15b-287a0c37b8e7" />
Nav:en, footern och alla sections i the body har nu 375px som computed width och inte 626px
