### PR TITLE
Feature and upsell section header styling

### DIFF
--- a/css/product-page.css
+++ b/css/product-page.css
@@ -359,7 +359,7 @@ img {
     }
 
     .feature-section-text-wrapper h3 {
-        font-size: 1.75rem; /* ca 28px */ /* Explicitly set to 24px to match upsell section h3 */
+        font-size: 1.75rem; /* ca 28px */ /* Explicitly set to 28px to match upsell section h3 */
         border-left: 0.313rem solid var(--red); /* ca 5px */
         padding-left: 0.5rem;
         margin-bottom: 2rem; /* Changed from padding to margin to not mess with the red styling*/
@@ -381,7 +381,7 @@ img {
     }
 
     .product-upsell-section h3 {
-        font-size: 1.75rem; /* ca 28px */ /* Explicitly set to 24px to match upsell section h3 */
+        font-size: 1.75rem; /* ca 28px */
         border-left: 0.313rem solid var(--red); /* ca 5px */
         padding-left: 0.5rem;
         margin-bottom: 0.75rem; /* ca 12px */


### PR DESCRIPTION
# Summary
Gjorde både h3 element i the feature section och upsell section till 28px och lade till den röda lilla stylingen. Denna PR tar även bort blå och gröna debugging borders

## Before
<img width="3840" height="4450" alt="Nshop-01-01-2026_07_34_PM" src="https://github.com/user-attachments/assets/5e8b7ad0-41e6-4839-b8bd-ec6fb94a22ab" />

## After
<img width="3840" height="4486" alt="Nshop-01-01-2026_07_38_PM" src="https://github.com/user-attachments/assets/b0d34c3b-3ac6-4893-908c-56cd7881334c" />
