### PR TITLE
Buy now button pixel border re-styling

### DIFF
--- a/css/product-page.css
+++ b/css/product-page.css
@@ -2,6 +2,7 @@
     /* COLORS */
     --green: #4CAF50;
     --green-darker: #45a049;
+    --green-darkest: #06402B;
 
     /* SPACING */
     --content-padding-block: 1.125rem; /* ca 18px */
@@ -121,10 +122,10 @@ img {
     /* We use shadows with 0 blur to create solid blocks of color */
     box-shadow: 
     /* The "Pixels" on the corners */ /* ca 6px */
-    -0.375rem 0 0 0 #ffffff, 
-    0.375rem 0 0 0 #ffffff, 
-    0 -0.375rem 0 0 #ffffff, 
-    0 0.375rem 0 0 #ffffff;
+    -0.375rem 0 0 0 var(--green-darkest), 
+    0.375rem 0 0 0 var(--green-darkest), 
+    0 -0.375rem 0 0 var(--green-darkest), 
+    0 0.375rem 0 0 var(--green-darkest);
   
     /* Some breathing room so that it doesn't touch other elements */
     margin: 0.5rem;
@@ -309,6 +310,11 @@ img {
         align-items: start;
         text-align: left;
         justify-items: start;
+    }
+
+    /* Center only the Buy Now button */
+    .product-buy-button {
+        justify-self: center;
     }
 
     .hero-img-wrapper {


### PR DESCRIPTION
https://trello.com/c/yiat8oUy/35-product-page-k%C3%B6p-nu-pixel-border-color

Noticed that since we changed the background color to black the pixel border of the buy button is not visible anymore haha
When I designed it I used a white background:
<img width="1646" height="860" alt="Screenshot from 2026-01-01 19-46-53" src="https://github.com/user-attachments/assets/73c8657c-fbc3-4217-a060-dd1adaed654d" />

Det är vitt nu:
<img width="2646" height="964" alt="Screenshot from 2026-01-01 19-49-24" src="https://github.com/user-attachments/assets/683296d5-bc18-4a78-9a66-d0445654bb5d" />

Behåll eller ändra till en annan färg?