### PR TITLE
Thin red section border separators

### DIFF
--- a/css/product-page.css
+++ b/css/product-page.css
@@ -299,7 +299,6 @@ img {
 
     .product-hero-section {
         min-height: 45rem; /* ca 720px */
-        padding-top: 5.75rem; /* ca 92px */
         grid-template-areas:
             "media title"
             "media price"


### PR DESCRIPTION
https://trello.com/c/hLogoHSj/34-product-page-section-separation-different-color-creative-section-separation

Ett till förslag från dagens Daily Scrum! Jag va i tankar att jag har tre sections och vill ända separera de lite snyggt. Vi kan ju inte bara sätta en annan bakgrundsfärg i en section i och med att vi har delade 1fr 8fr 1fr side columns på våra sidor. Inte utan att stretcha ut hela sectionen med width: 100% iaf, vilket blir fult. men det här är en snygg lösning! En tunn 2px röd border bottom bara:

<img width="2552" height="1112" alt="Screenshot from 2026-01-02 08-22-00" src="https://github.com/user-attachments/assets/962e61df-8f6f-4a1f-824a-4c5fa0d3f2b8" />

<img width="2662" height="1068" alt="Screenshot from 2026-01-02 08-22-17" src="https://github.com/user-attachments/assets/fef3c988-57aa-4af7-be15-fbab5881bd55" />

I like it a lot!

