### PR TITLE
Fixing hero section styling on mobile and tablet

### DIFF
--- a/css/product-page.css
+++ b/css/product-page.css
@@ -316,6 +316,11 @@ img {
     .hero-thumbnails img {
         height: 4.75rem; /* ca 76px */
     }
+    
+    /* EDIT: Gör h1:an lite större också */
+    .product-title {
+        font-size: 2.5rem; /* ca 40px */
+    }
 
     .upsell-section-grid {
         grid-template-columns: repeat(3, minmax(0, 1fr));


### PR DESCRIPTION
My h1 on mobile was not visible for the longest time, now it is with recent changes merged to main haha
This does bring another improvement opportunity to the surface:
<img width="800" height="1262" alt="Screenshot from 2026-01-03 18-31-32" src="https://github.com/user-attachments/assets/e1b9b7f2-3074-41f9-a457-4f8dd8f24c95" />
The red h1 styling works perfect on desktop. But not so much on mobile and tablet where the content is stacked on top of each other. So the plan of action:
* Remove the red left border
* Center the h1
* Will also use this PR to reduce the gap between the nav/header and the h1