### PR TITLE
Fix styling on tablet

### DIFF
--- a/css/product-page.css
+++ b/css/product-page.css
@@ -304,6 +304,7 @@ img {
     display: inline-block; /* Let them sit side-by-side */
 }
 
+/* Fix the styling here */
 /* tablet */
 @media screen and (min-width:768px) {
     section {


### PR DESCRIPTION
This is a direct continuation of #73 
I finished that one and it looked good on mobile. But on tablet...
<img width="838" height="1068" alt="Screenshot from 2026-01-03 18-53-29" src="https://github.com/user-attachments/assets/f780ac7b-b032-4ec9-9f90-0542cfd09cdb" />
Not so good haha. And also the red styling still persists on tablet when it shouldn't for some reason. I put it only on the Small Desktop media query and above. So this is something I will have to figure out. The gap should be fixed if I can get to the root of this problem as well. Since the tablet media query is very minimal at the moment:
```
/* Fix the styling here */
/* tablet */
@media screen and (min-width:768px) {
    section {
        padding-inline: 3.25rem; /* ca 52px */
    }

    .upsell-section-grid {
        grid-template-columns: repeat(3, minmax(0, 1fr));
    }

    .feature-section-text-wrapper {
        width: 75ch;
    }
}

/* small desktop */
@media screen and (min-width:960px) {
```

It feels like the tablet media query and CSS is not properly communicating with the html?
This PR will also include styling the thumnail images to look as good as they do on mobile. This might also get fixed automatically as I get to the root problem