### PR TITLE
More breathing space, specifically in the feature setcion on desktop

### DIFF
--- a/css/product-page.css
+++ b/css/product-page.css
@@ -337,7 +337,7 @@ img {
 @media screen and (min-width:960px) {
     section {
         padding-block: 5.125rem; /* 82px */ 
-        padding-inline: 4.5rem; /* 72px */
+        /* Removed! No inline padding needed on dekstop */
     }
 
     .div-side {
@@ -419,6 +419,7 @@ img {
         display: grid;
         grid-template-columns: 1fr 2fr;
         gap: 0.75rem; /* ca 12px */
+        padding-inline: 0; /* Sätt denna explcitly till 0 för att få mer andningsrum */
     }
 
     .feature-section-text-wrapper {


### PR DESCRIPTION
Bilderna såg lite crammed ut, speciellt på small desktop så tog bort inline padding help på desktop och satte den explicitly till 0 in the feature section

## Before
<img width="2878" height="1348" alt="Screenshot from 2026-01-03 20-38-18" src="https://github.com/user-attachments/assets/0f939010-edea-4f14-93fc-5d2a543802a5" />

## After
<img width="2878" height="1350" alt="Screenshot from 2026-01-03 20-37-37" src="https://github.com/user-attachments/assets/786ab3ca-7266-4520-be90-97a2688c8ce0" />
