### PR TITLE
Info box now has min-width: 100%

### DIFF
--- a/css/product-page.css
+++ b/css/product-page.css
@@ -131,6 +131,9 @@ img {
     padding: 0.375rem; /* ca 6px */
     margin-inline: 0.5rem;
     grid-area: info;
+    
+    /* Märkte när jag började på en riktig sida att detta behövs! */
+    min-width: 100%;
 }
 
 .sleeping-pikachu {


### PR DESCRIPTION
# Summary
Trello kort: https://trello.com/c/u4czhHmo/43-product-page-fixa-min-width-p%C3%A5-info-box
This PR is directly tied and connected to #83 
Vi märkte när jag började bygga ut en riktigt product page att info box:en behöver min-width så att den behåller min bredd även när texten inte tar en hel rad:
<img width="1916" height="944" alt="Screenshot from 2026-01-04 14-03-36" src="https://github.com/user-attachments/assets/1c7e26af-f0e4-4f7b-a167-347ddf9202f5" />

## Solution
Detta löses väldigt simpelt genom att sätta `min-width: 100%` på .product-info-small i product-page.css.
Ska rebase den andra branchen efter att jag mergeat in detta i main och klistra in resulat!
Lösningen blev approved live under dagens daily scrum och programmering tillsammans